### PR TITLE
Expose health and metrics endpoints

### DIFF
--- a/k8s/apis/auth-api.yaml
+++ b/k8s/apis/auth-api.yaml
@@ -10,8 +10,17 @@ spec:
       containers:
       - name: auth
         image: python:3.11-slim
-        command: ["python","/app/app.py"]
+        command: ["/bin/sh", "-c"]
+        args: ["pip install flask pyjwt prometheus_flask_exporter && python /app/app.py"]
         ports: [ { containerPort: 5000 } ]
+        readinessProbe:
+          httpGet: { path: /health, port: 5000 }
+          initialDelaySeconds: 5
+          periodSeconds: 5
+        livenessProbe:
+          httpGet: { path: /health, port: 5000 }
+          initialDelaySeconds: 15
+          periodSeconds: 10
         volumeMounts: [ { name: code, mountPath: /app } ]
       volumes: [ { name: code, configMap: { name: auth-api-code } } ]
 ---
@@ -29,7 +38,8 @@ data:
   app.py: |
     from flask import Flask, request, jsonify
     import jwt, datetime
-    app = Flask(__name__); SECRET="super-secret-key"
+    from prometheus_flask_exporter import PrometheusMetrics
+    app = Flask(__name__); SECRET="super-secret-key"; metrics = PrometheusMetrics(app)
     @app.get("/health")
     def h(): return ("ok",200)
     @app.post("/auth/login")

--- a/k8s/apis/cas-api.yaml
+++ b/k8s/apis/cas-api.yaml
@@ -10,8 +10,17 @@ spec:
       containers:
       - name: cas
         image: python:3.11-slim
-        command: ["python","/app/app.py"]
+        command: ["/bin/sh", "-c"]
+        args: ["pip install flask pyjwt prometheus_flask_exporter && python /app/app.py"]
         ports: [ { containerPort: 5004 } ]
+        readinessProbe:
+          httpGet: { path: /health, port: 5004 }
+          initialDelaySeconds: 5
+          periodSeconds: 5
+        livenessProbe:
+          httpGet: { path: /health, port: 5004 }
+          initialDelaySeconds: 15
+          periodSeconds: 10
         volumeMounts: [ { name: code, mountPath: /app } ]
       volumes: [ { name: code, configMap: { name: cas-api-code } } ]
 ---
@@ -28,7 +37,8 @@ metadata: { name: cas-api-code, namespace: ott-platform }
 data:
   app.py: |
     from flask import Flask, request, jsonify
-    app = Flask(__name__)
+    from prometheus_flask_exporter import PrometheusMetrics
+    app = Flask(__name__); metrics = PrometheusMetrics(app)
     @app.get("/health")
     def h(): return ("ok",200)
     @app.get("/ready")

--- a/k8s/apis/catalog-api.yaml
+++ b/k8s/apis/catalog-api.yaml
@@ -10,8 +10,17 @@ spec:
       containers:
       - name: catalog
         image: python:3.11-slim
-        command: ["python","/app/app.py"]
+        command: ["/bin/sh", "-c"]
+        args: ["pip install flask pyjwt prometheus_flask_exporter && python /app/app.py"]
         ports: [ { containerPort: 5002 } ]
+        readinessProbe:
+          httpGet: { path: /health, port: 5002 }
+          initialDelaySeconds: 5
+          periodSeconds: 5
+        livenessProbe:
+          httpGet: { path: /health, port: 5002 }
+          initialDelaySeconds: 15
+          periodSeconds: 10
         volumeMounts: [ { name: code, mountPath: /app } ]
       volumes: [ { name: code, configMap: { name: catalog-api-code } } ]
 ---
@@ -28,7 +37,8 @@ metadata: { name: catalog-api-code, namespace: ott-platform }
 data:
   app.py: |
     from flask import Flask, jsonify
-    app=Flask(__name__)
+    from prometheus_flask_exporter import PrometheusMetrics
+    app=Flask(__name__); metrics = PrometheusMetrics(app)
     CDN="http://cdn-edge-service.ott-platform.svc.cluster.local"
     LICENSE="http://license-api-service.ott-platform.svc.cluster.local/license"
     @app.get("/health")

--- a/k8s/apis/license-api.yaml
+++ b/k8s/apis/license-api.yaml
@@ -10,8 +10,17 @@ spec:
       containers:
       - name: license
         image: python:3.11-slim
-        command: ["python","/app/app.py"]
+        command: ["/bin/sh", "-c"]
+        args: ["pip install flask pyjwt prometheus_flask_exporter && python /app/app.py"]
         ports: [ { containerPort: 5003 } ]
+        readinessProbe:
+          httpGet: { path: /health, port: 5003 }
+          initialDelaySeconds: 5
+          periodSeconds: 5
+        livenessProbe:
+          httpGet: { path: /health, port: 5003 }
+          initialDelaySeconds: 15
+          periodSeconds: 10
         volumeMounts: [ { name: code, mountPath: /app } ]
       volumes: [ { name: code, configMap: { name: license-api-code } } ]
 ---
@@ -28,7 +37,8 @@ metadata: { name: license-api-code, namespace: ott-platform }
 data:
   app.py: |
     from flask import Flask, request, jsonify
-    app = Flask(__name__)
+    from prometheus_flask_exporter import PrometheusMetrics
+    app = Flask(__name__); metrics = PrometheusMetrics(app)
     @app.get("/health")
     def h(): return ("ok",200)
     @app.get("/ready")

--- a/k8s/apis/subscription-api.yaml
+++ b/k8s/apis/subscription-api.yaml
@@ -10,9 +10,18 @@ spec:
       containers:
       - name: subscription
         image: python:3.11-slim
-        command: ["python","/app/app.py"]
+        command: ["/bin/sh", "-c"]
+        args: ["pip install flask pyjwt prometheus_flask_exporter && python /app/app.py"]
         ports: [ { containerPort: 5001 } ]
         env: [ { name: JWT_SECRET, value: "super-secret-key" } ]
+        readinessProbe:
+          httpGet: { path: /health, port: 5001 }
+          initialDelaySeconds: 5
+          periodSeconds: 5
+        livenessProbe:
+          httpGet: { path: /health, port: 5001 }
+          initialDelaySeconds: 15
+          periodSeconds: 10
         volumeMounts: [ { name: code, mountPath: /app } ]
       volumes: [ { name: code, configMap: { name: subscription-api-code } } ]
 ---
@@ -30,8 +39,9 @@ data:
   app.py: |
     from flask import Flask, request, jsonify
     import jwt
+    from prometheus_flask_exporter import PrometheusMetrics
     app = Flask(__name__)
-    SECRET = "super-secret-key"
+    SECRET = "super-secret-key"; metrics = PrometheusMetrics(app)
     @app.get("/health")
     def h(): return ("ok",200)
     @app.get("/ready")


### PR DESCRIPTION
## Summary
- ensure each API installs dependencies before running
- add readiness and liveness probes on /health
- expose Prometheus metrics via PrometheusMetrics in app code

## Testing
- `pip install flask pyjwt prometheus_flask_exporter pyyaml` *(failed: Could not find a version that satisfies the requirement flask)*

------
https://chatgpt.com/codex/tasks/task_e_68bb3d097b088325940f2156df6c1f7b