### PR TITLE
Add ServiceMonitors for APIs

### DIFF
--- a/k8s/monitoring/service-monitors.yaml
+++ b/k8s/monitoring/service-monitors.yaml
@@ -3,7 +3,35 @@ kind: ServiceMonitor
 metadata: { name: api-auth-monitor, namespace: ott-platform }
 spec:
   selector: { matchLabels: { app: auth-api } }
-  endpoints: [ { port: http, path: /health, interval: 15s } ]
+  endpoints: [ { port: http, path: /metrics, interval: 15s } ]
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata: { name: api-subscription-monitor, namespace: ott-platform }
+spec:
+  selector: { matchLabels: { app: subscription-api } }
+  endpoints: [ { port: http, path: /metrics, interval: 15s } ]
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata: { name: api-catalog-monitor, namespace: ott-platform }
+spec:
+  selector: { matchLabels: { app: catalog-api } }
+  endpoints: [ { port: http, path: /metrics, interval: 15s } ]
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata: { name: api-license-monitor, namespace: ott-platform }
+spec:
+  selector: { matchLabels: { app: license-api } }
+  endpoints: [ { port: http, path: /metrics, interval: 15s } ]
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata: { name: api-cas-monitor, namespace: ott-platform }
+spec:
+  selector: { matchLabels: { app: cas-api } }
+  endpoints: [ { port: http, path: /metrics, interval: 15s } ]
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
@@ -11,3 +39,4 @@ metadata: { name: cdn-monitor, namespace: ott-platform }
 spec:
   selector: { matchLabels: { app: cdn-edge } }
   endpoints: [ { port: http, path: /metrics, interval: 10s } ]
+


### PR DESCRIPTION
## Summary
- expose metrics for auth, subscription, catalog, license and cas APIs
- keep cdn-edge metrics endpoint in ServiceMonitor

## Testing
- `kubectl apply --dry-run=client -f k8s/monitoring/service-monitors.yaml` *(fails: command not found)*
- `python - <<'PY' ...` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `pip install pyyaml` *(fails: Could not find a version due to proxy restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68bb3d0a9dc083258dcbb6c400b3a76d