### PR TITLE
Add Istio authorization policies for core APIs

### DIFF
--- a/k8s/istio/security.yaml
+++ b/k8s/istio/security.yaml
@@ -10,3 +10,35 @@ spec:
   selector: { matchLabels: { app: license-api } }
   rules:
   - to: [ { operation: { methods: ["POST"], paths: ["/license"] } } ]
+---
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata: { name: auth-api-policy, namespace: ott-platform }
+spec:
+  selector: { matchLabels: { app: auth-api } }
+  rules:
+  - to: [ { operation: { methods: ["POST"], paths: ["/auth/*"] } } ]
+---
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata: { name: subscription-api-policy, namespace: ott-platform }
+spec:
+  selector: { matchLabels: { app: subscription-api } }
+  rules:
+  - to: [ { operation: { methods: ["GET"], paths: ["/subscription/*"] } } ]
+---
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata: { name: catalog-api-policy, namespace: ott-platform }
+spec:
+  selector: { matchLabels: { app: catalog-api } }
+  rules:
+  - to: [ { operation: { methods: ["GET"], paths: ["/catalog/*"] } } ]
+---
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata: { name: cas-api-policy, namespace: ott-platform }
+spec:
+  selector: { matchLabels: { app: cas-api } }
+  rules:
+  - to: [ { operation: { methods: ["POST"], paths: ["/cas/*"] } } ]


### PR DESCRIPTION
## Summary
- enforce per-API authorization policies for auth, subscription, catalog and CAS services

## Testing
- `yamllint k8s/istio/security.yaml` *(fails: command not found)*
- `kubectl apply --dry-run=client -f k8s/istio/security.yaml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb3d104ea48325b9c3ea7fd2c42b84