### PR TITLE
Add HLS transcoder pod and update CDN routing

### DIFF
--- a/k8s/cdn/cdn-edge.yaml
+++ b/k8s/cdn/cdn-edge.yaml
@@ -8,13 +8,13 @@ data:
       listen 80;
       location /health { return 200 "ok\n"; add_header Content-Type text/plain; }
       location ~* \.(m3u8|mpd)$ {
-        proxy_pass http://vlc-streaming-service.ott-platform.svc.cluster.local;
+        proxy_pass http://hls-transcoder-service.ott-platform.svc.cluster.local;
         proxy_cache video_cache; proxy_cache_valid 200 10s;
         add_header X-Cache-Status $upstream_cache_status;
         add_header Access-Control-Allow-Origin *;
       }
       location ~* \.(ts|m4s|mp4)$ {
-        proxy_pass http://vlc-streaming-service.ott-platform.svc.cluster.local;
+        proxy_pass http://hls-transcoder-service.ott-platform.svc.cluster.local;
         proxy_cache video_cache; proxy_cache_valid 200 60s;
         add_header X-Cache-Status $upstream_cache_status;
         add_header Access-Control-Allow-Origin *;

--- a/k8s/vlc/hls-transcoder.yaml
+++ b/k8s/vlc/hls-transcoder.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata: { name: hls-transcoder, namespace: ott-platform, labels: { app: hls-transcoder } }
+spec:
+  containers:
+  - name: ffmpeg
+    image: jrottenberg/ffmpeg:4.4-alpine
+    command: ["/bin/sh","-c"]
+    args:
+      - >-
+        ffmpeg -re -f lavfi -i testsrc=size=1280x720:rate=30 -f lavfi -i sine=frequency=440:sample_rate=48000
+        -c:v libx264 -preset veryfast -c:a aac -f hls -hls_time 4 -hls_list_size 5
+        -hls_flags delete_segments -hls_segment_filename /hls/segment%03d.ts /hls/master.m3u8
+    volumeMounts: [ { name: hls-media, mountPath: /hls } ]
+  - name: nginx
+    image: nginx:1.25-alpine
+    ports: [ { containerPort: 80 } ]
+    volumeMounts: [ { name: hls-media, mountPath: /usr/share/nginx/html/media/demo } ]
+  volumes:
+  - { name: hls-media, emptyDir: {} }
+---
+apiVersion: v1
+kind: Service
+metadata: { name: hls-transcoder-service, namespace: ott-platform }
+spec:
+  selector: { app: hls-transcoder }
+  ports: [ { name: http, port: 80, targetPort: 80 } ]


### PR DESCRIPTION
## Summary
- add ffmpeg+nginx HLS transcoder Pod and service
- route CDN edge cache to hls-transcoder service

## Testing
- `kubectl version --client` *(fails: command not found)*
- `kubectl apply --dry-run=client -f k8s/vlc/hls-transcoder.yaml` *(fails: command not found)*
- `kubectl apply --dry-run=client -f k8s/cdn/cdn-edge.yaml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb3d13ba408325902f1a72def18a58