### PR TITLE
feat: medir segmentos en k6

### DIFF
--- a/k8s/testing/k6-configmap.yaml
+++ b/k8s/testing/k6-configmap.yaml
@@ -8,7 +8,8 @@ data:
     import { Trend, Rate } from 'k6/metrics';
     export let errorRate = new Rate('ott_errors');
     export let startupTime = new Trend('ott_startup_time');
-    export let options = { vus: 20, duration: '2m', thresholds: { 'ott_errors': ['rate<0.02'], 'ott_startup_time': ['p(95)<2500'] } };
+    export let segmentFetch = new Trend('segment_fetch');
+    export let options = { vus: 20, duration: '2m', thresholds: { 'ott_errors': ['rate<0.02'], 'ott_startup_time': ['p(95)<2500'], 'segment_fetch': ['p(95)<1500'] } };
     export default function () {
       group('OTT Journey', function () {
         const base = 'http://istio-ingressgateway.istio-system.svc.cluster.local';
@@ -25,7 +26,20 @@ data:
         let lic = http.post(licenseUrl, JSON.stringify({contentId:'content123', deviceId:'device456'}), { headers: {'Content-Type':'application/json'} });
         check(lic, { 'license 200': r => r.status === 200 }) || errorRate.add(1);
         // CDN manifest
-        let man = http.get('http://cdn-edge-service.ott-platform.svc.cluster.local/media/demo/master.m3u8'); check(man, { 'manifest 200': r => r.status === 200 }) || errorRate.add(1);
-        let t1 = Date.now(); startupTime.add(t1 - t0);
+        const manifestUrl = 'http://cdn-edge-service.ott-platform.svc.cluster.local/media/demo/master.m3u8';
+        let man = http.get(manifestUrl); check(man, { 'manifest 200': r => r.status === 200 }) || errorRate.add(1);
+        let segments = man.body.match(/https?:\/\/[^\n]+\.(ts|m4s)/g) || [];
+        if (segments.length < 3) {
+          const baseUrl = manifestUrl.substring(0, manifestUrl.lastIndexOf('/') + 1);
+          let rels = man.body.match(/^(?!#)([^\n]+\.(ts|m4s))/gm) || [];
+          segments = segments.concat(rels.map(s => baseUrl + s));
+        }
+        segments.slice(0,3).forEach((url, i) => {
+          let s0 = Date.now();
+          let seg = http.get(url);
+          segmentFetch.add(Date.now() - s0);
+          check(seg, { [`segment ${i} 200`]: r => r.status === 200 }) || errorRate.add(1);
+          if (i === 0) startupTime.add(Date.now() - t0);
+        });
       });
     }


### PR DESCRIPTION
## Resumen
- añadir métrica `segmentFetch` para medir la descarga de segmentos en k6
- extraer al menos 3 segmentos del manifest y calcular `startupTime`
- agregar threshold `segment_fetch p95 < 1500ms`

## Testing
- `npm test` *(falla: no se encontró package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bb3d14ed9c8325877655b668f93add