### PR TITLE
Add ArgoCD Application manifest

### DIFF
--- a/gitops/argocd/apps.yaml
+++ b/gitops/argocd/apps.yaml
@@ -1,0 +1,14 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ott-platform
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/CodelyTV/ott-k8s-lab-v7.git
+    targetRevision: HEAD
+    path: k8s/
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: ott-platform


### PR DESCRIPTION
## Summary
- add ArgoCD Application manifest targeting k8s/ directory and ott-platform namespace

## Testing
- `kubectl apply --dry-run=client -f gitops/argocd/apps.yaml` *(command not found: kubectl)*
- `pip install yamllint` *(HTTP 403: proxy error)*
- `pip install pyyaml` *(HTTP 403: proxy error)*

------
https://chatgpt.com/codex/tasks/task_e_68bb3d16b0ec8325be7fc628be469586