### PR TITLE
chore: update ArgoCD app revision and sync policy

### DIFF
--- a/gitops/argocd/app.yaml
+++ b/gitops/argocd/app.yaml
@@ -7,8 +7,14 @@ spec:
   project: default
   source:
     repoURL: https://github.com/CodelyTV/ott-k8s-lab-v7.git
-    targetRevision: HEAD
+    targetRevision: main
     path: k8s/
   destination:
     server: https://kubernetes.default.svc
     namespace: ott-platform
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true


### PR DESCRIPTION
## Summary
- use `main` as the ArgoCD application's `targetRevision`
- enable automated sync with prune, self-heal, and namespace creation

## Testing
- `ruby -r yaml -e 'YAML.load_file("gitops/argocd/app.yaml"); puts "YAML OK"'`
- `pip install yamllint` *(fails: Could not find a version that satisfies the requirement yamllint - proxy 403)*

------
https://chatgpt.com/codex/tasks/task_e_68be0fbf98408325ad4816374a40bf7b