### PR TITLE
Configure production domains and TLS for gateway

### DIFF
--- a/k8s/cdn/cdn-edge.yaml
+++ b/k8s/cdn/cdn-edge.yaml
@@ -11,13 +11,13 @@ data:
         proxy_pass http://hls-transcoder-svc.ott-platform.svc.cluster.local;
         proxy_cache video_cache; proxy_cache_valid 200 10s;
         add_header X-Cache-Status $upstream_cache_status;
-        add_header Access-Control-Allow-Origin *;
+        add_header Access-Control-Allow-Origin https://ott.example.com;
       }
       location ~* \.(ts|m4s|mp4)$ {
         proxy_pass http://hls-transcoder-svc.ott-platform.svc.cluster.local;
         proxy_cache video_cache; proxy_cache_valid 200 60s;
         add_header X-Cache-Status $upstream_cache_status;
-        add_header Access-Control-Allow-Origin *;
+        add_header Access-Control-Allow-Origin https://ott.example.com;
       }
     }
 ---

--- a/k8s/istio/gateway.yaml
+++ b/k8s/istio/gateway.yaml
@@ -3,4 +3,9 @@ kind: Gateway
 metadata: { name: ott-gateway, namespace: ott-platform }
 spec:
   selector: { istio: ingressgateway }
-  servers: [ { port: { number: 80, name: http, protocol: HTTP }, hosts: ["*"] } ]
+  servers:
+  - port: { number: 80, name: http, protocol: HTTP }
+    hosts: ["ott.example.com"]
+  - port: { number: 443, name: https, protocol: HTTPS }
+    hosts: ["ott.example.com"]
+    tls: { mode: SIMPLE, credentialName: ott-gateway-cert }

--- a/k8s/istio/virtual-services.yaml
+++ b/k8s/istio/virtual-services.yaml
@@ -2,7 +2,7 @@ apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 metadata: { name: api-routes, namespace: ott-platform }
 spec:
-  hosts: ["*"]
+  hosts: ["ott.example.com"]
   gateways: ["ott-gateway"]
   http:
   - match: [{ uri: { prefix: "/auth" } }]


### PR DESCRIPTION
## Summary
- replace wildcard hosts with `ott.example.com`
- configure HTTPS server with TLS secret on Istio gateway
- restrict CDN CORS headers to production domain

## Testing
- `pip install yamllint` *(fails: Could not connect to proxy)*
- `pip install pyyaml` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68be0fc08a9883258e9ce36c28bab36f