### PR TITLE
Containerize Python APIs and update deployments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/apis/auth/Dockerfile
+++ b/apis/auth/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY app.py .
+CMD ["python", "app.py"]

--- a/apis/auth/app.py
+++ b/apis/auth/app.py
@@ -1,0 +1,22 @@
+from flask import Flask, request, jsonify
+import jwt, datetime
+from prometheus_flask_exporter import PrometheusMetrics
+
+app = Flask(__name__)
+SECRET = "super-secret-key"
+metrics = PrometheusMetrics(app)
+
+@app.get("/health")
+def h():
+    return ("ok", 200)
+
+@app.post("/auth/login")
+def login():
+    d = request.get_json(force=True) or {}
+    if d.get("username") == "user" and d.get("password") == "pass":
+        tok = jwt.encode({"sub": "user", "exp": datetime.datetime.utcnow() + datetime.timedelta(minutes=30)}, SECRET, algorithm="HS256")
+        return jsonify(token=tok)
+    return jsonify(error="invalid"), 401
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=5000)

--- a/apis/auth/requirements.txt
+++ b/apis/auth/requirements.txt
@@ -1,0 +1,3 @@
+flask
+pyjwt
+prometheus_flask_exporter

--- a/apis/cas/Dockerfile
+++ b/apis/cas/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY app.py .
+CMD ["python", "app.py"]

--- a/apis/cas/app.py
+++ b/apis/cas/app.py
@@ -1,0 +1,21 @@
+from flask import Flask, request, jsonify
+from prometheus_flask_exporter import PrometheusMetrics
+
+app = Flask(__name__)
+metrics = PrometheusMetrics(app)
+
+@app.get("/health")
+def h():
+    return ("ok", 200)
+
+@app.get("/ready")
+def r():
+    return ("ok", 200)
+
+@app.post("/cas/authorize")
+def authorize():
+    b = request.get_json(force=True) or {}
+    return jsonify(allowed=b.get("tier") in ("premium", "gold"))
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=5004)

--- a/apis/cas/requirements.txt
+++ b/apis/cas/requirements.txt
@@ -1,0 +1,3 @@
+flask
+pyjwt
+prometheus_flask_exporter

--- a/apis/catalog/Dockerfile
+++ b/apis/catalog/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY app.py .
+CMD ["python", "app.py"]

--- a/apis/catalog/app.py
+++ b/apis/catalog/app.py
@@ -1,0 +1,19 @@
+from flask import Flask, jsonify
+from prometheus_flask_exporter import PrometheusMetrics
+
+app = Flask(__name__)
+metrics = PrometheusMetrics(app)
+
+CDN = "http://cdn-edge-service.ott-platform.svc.cluster.local"
+LICENSE = "http://license-api-service.ott-platform.svc.cluster.local/license"
+
+@app.get("/health")
+def h():
+    return ("ok", 200)
+
+@app.get("/catalog/<cid>")
+def c(cid):
+    return jsonify(contentId=cid, manifestUrl=f"{CDN}/media/demo/master.m3u8", licenseServerUrl=LICENSE)
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=5002)

--- a/apis/catalog/requirements.txt
+++ b/apis/catalog/requirements.txt
@@ -1,0 +1,3 @@
+flask
+pyjwt
+prometheus_flask_exporter

--- a/apis/license/Dockerfile
+++ b/apis/license/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY app.py .
+CMD ["python", "app.py"]

--- a/apis/license/app.py
+++ b/apis/license/app.py
@@ -1,0 +1,23 @@
+from flask import Flask, request, jsonify
+from prometheus_flask_exporter import PrometheusMetrics
+
+app = Flask(__name__)
+metrics = PrometheusMetrics(app)
+
+@app.get("/health")
+def h():
+    return ("ok", 200)
+
+@app.get("/ready")
+def r():
+    return ("ok", 200)
+
+@app.post("/license")
+def license_issue():
+    b = request.get_json(force=True) or {}
+    if not b.get("contentId") or not b.get("deviceId"):
+        return jsonify(ok=False, error="missing fields"), 400
+    return jsonify(ok=True, licenseKey="ABC123-FAKE-KEY")
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=5003)

--- a/apis/license/requirements.txt
+++ b/apis/license/requirements.txt
@@ -1,0 +1,3 @@
+flask
+pyjwt
+prometheus_flask_exporter

--- a/apis/subscription/Dockerfile
+++ b/apis/subscription/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY app.py .
+CMD ["python", "app.py"]

--- a/apis/subscription/app.py
+++ b/apis/subscription/app.py
@@ -1,0 +1,27 @@
+from flask import Flask, request, jsonify
+import jwt
+from prometheus_flask_exporter import PrometheusMetrics
+
+app = Flask(__name__)
+SECRET = "super-secret-key"
+metrics = PrometheusMetrics(app)
+
+@app.get("/health")
+def h():
+    return ("ok", 200)
+
+@app.get("/ready")
+def r():
+    return ("ok", 200)
+
+@app.get("/subscription/check/<content_id>")
+def check(content_id):
+    try:
+        token = request.headers.get("Authorization", "").split(" ")[1]
+        jwt.decode(token, SECRET, algorithms=["HS256"])
+        return jsonify(entitled=(content_id != "blocked123"))
+    except Exception as e:
+        return jsonify(error="unauthorized", detail=str(e)), 401
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=5001)

--- a/apis/subscription/requirements.txt
+++ b/apis/subscription/requirements.txt
@@ -1,0 +1,3 @@
+flask
+pyjwt
+prometheus_flask_exporter

--- a/k8s/apis/auth-api.yaml
+++ b/k8s/apis/auth-api.yaml
@@ -9,9 +9,7 @@ spec:
     spec:
       containers:
       - name: auth
-        image: python:3.11-slim
-        command: ["/bin/sh", "-c"]
-        args: ["pip install flask pyjwt prometheus_flask_exporter && python /app/app.py"]
+        image: ghcr.io/example/auth-api:latest
         ports: [ { containerPort: 5000 } ]
         readinessProbe:
           httpGet: { path: /health, port: 5000 }
@@ -24,8 +22,6 @@ spec:
         resources:
           requests: { cpu: "100m", memory: "128Mi" }
           limits:   { cpu: "300m", memory: "512Mi" }
-        volumeMounts: [ { name: code, mountPath: /app } ]
-      volumes: [ { name: code, configMap: { name: auth-api-code } } ]
 ---
 apiVersion: v1
 kind: Service
@@ -33,23 +29,3 @@ metadata: { name: auth-api-service, namespace: ott-platform }
 spec:
   selector: { app: auth-api }
   ports: [ { name: http, port: 80, targetPort: 5000 } ]
----
-apiVersion: v1
-kind: ConfigMap
-metadata: { name: auth-api-code, namespace: ott-platform }
-data:
-  app.py: |
-    from flask import Flask, request, jsonify
-    import jwt, datetime
-    from prometheus_flask_exporter import PrometheusMetrics
-    app = Flask(__name__); SECRET="super-secret-key"; metrics = PrometheusMetrics(app)
-    @app.get("/health")
-    def h(): return ("ok",200)
-    @app.post("/auth/login")
-    def login():
-        d = request.get_json(force=True) or {}
-        if d.get("username")=="user" and d.get("password")=="pass":
-            tok = jwt.encode({"sub":"user","exp":datetime.datetime.utcnow()+datetime.timedelta(minutes=30)}, SECRET, algorithm="HS256")
-            return jsonify(token=tok)
-        return jsonify(error="invalid"),401
-    if __name__=="__main__": app.run(host="0.0.0.0", port=5000)

--- a/k8s/apis/cas-api.yaml
+++ b/k8s/apis/cas-api.yaml
@@ -9,9 +9,7 @@ spec:
     spec:
       containers:
       - name: cas
-        image: python:3.11-slim
-        command: ["/bin/sh", "-c"]
-        args: ["pip install flask pyjwt prometheus_flask_exporter && python /app/app.py"]
+        image: ghcr.io/example/cas-api:latest
         ports: [ { containerPort: 5004 } ]
         readinessProbe:
           httpGet: { path: /health, port: 5004 }
@@ -24,8 +22,6 @@ spec:
         resources:
           requests: { cpu: "100m", memory: "128Mi" }
           limits:   { cpu: "300m", memory: "512Mi" }
-        volumeMounts: [ { name: code, mountPath: /app } ]
-      volumes: [ { name: code, configMap: { name: cas-api-code } } ]
 ---
 apiVersion: v1
 kind: Service
@@ -33,21 +29,3 @@ metadata: { name: cas-api-service, namespace: ott-platform }
 spec:
   selector: { app: cas-api }
   ports: [ { name: http, port: 80, targetPort: 5004 } ]
----
-apiVersion: v1
-kind: ConfigMap
-metadata: { name: cas-api-code, namespace: ott-platform }
-data:
-  app.py: |
-    from flask import Flask, request, jsonify
-    from prometheus_flask_exporter import PrometheusMetrics
-    app = Flask(__name__); metrics = PrometheusMetrics(app)
-    @app.get("/health")
-    def h(): return ("ok",200)
-    @app.get("/ready")
-    def r(): return ("ok",200)
-    @app.post("/cas/authorize")
-    def authorize():
-      b = request.get_json(force=True) or {}
-      return jsonify(allowed=b.get("tier") in ("premium","gold"))
-    if __name__=="__main__": app.run(host="0.0.0.0", port=5004)

--- a/k8s/apis/catalog-api.yaml
+++ b/k8s/apis/catalog-api.yaml
@@ -9,9 +9,7 @@ spec:
     spec:
       containers:
       - name: catalog
-        image: python:3.11-slim
-        command: ["/bin/sh", "-c"]
-        args: ["pip install flask pyjwt prometheus_flask_exporter && python /app/app.py"]
+        image: ghcr.io/example/catalog-api:latest
         ports: [ { containerPort: 5002 } ]
         readinessProbe:
           httpGet: { path: /health, port: 5002 }
@@ -24,8 +22,6 @@ spec:
         resources:
           requests: { cpu: "100m", memory: "128Mi" }
           limits:   { cpu: "300m", memory: "512Mi" }
-        volumeMounts: [ { name: code, mountPath: /app } ]
-      volumes: [ { name: code, configMap: { name: catalog-api-code } } ]
 ---
 apiVersion: v1
 kind: Service
@@ -33,20 +29,3 @@ metadata: { name: catalog-api-service, namespace: ott-platform }
 spec:
   selector: { app: catalog-api }
   ports: [ { name: http, port: 80, targetPort: 5002 } ]
----
-apiVersion: v1
-kind: ConfigMap
-metadata: { name: catalog-api-code, namespace: ott-platform }
-data:
-  app.py: |
-    from flask import Flask, jsonify
-    from prometheus_flask_exporter import PrometheusMetrics
-    app=Flask(__name__); metrics = PrometheusMetrics(app)
-    CDN="http://cdn-edge-service.ott-platform.svc.cluster.local"
-    LICENSE="http://license-api-service.ott-platform.svc.cluster.local/license"
-    @app.get("/health")
-    def h(): return ("ok",200)
-    @app.get("/catalog/<cid>")
-    def c(cid):
-        return jsonify(contentId=cid, manifestUrl=f"{CDN}/media/demo/master.m3u8", licenseServerUrl=LICENSE)
-    if __name__=="__main__": app.run(host="0.0.0.0", port=5002)

--- a/k8s/apis/license-api.yaml
+++ b/k8s/apis/license-api.yaml
@@ -9,9 +9,7 @@ spec:
     spec:
       containers:
       - name: license
-        image: python:3.11-slim
-        command: ["/bin/sh", "-c"]
-        args: ["pip install flask pyjwt prometheus_flask_exporter && python /app/app.py"]
+        image: ghcr.io/example/license-api:latest
         ports: [ { containerPort: 5003 } ]
         readinessProbe:
           httpGet: { path: /health, port: 5003 }
@@ -24,8 +22,6 @@ spec:
         resources:
           requests: { cpu: "100m", memory: "128Mi" }
           limits:   { cpu: "300m", memory: "512Mi" }
-        volumeMounts: [ { name: code, mountPath: /app } ]
-      volumes: [ { name: code, configMap: { name: license-api-code } } ]
 ---
 apiVersion: v1
 kind: Service
@@ -33,24 +29,3 @@ metadata: { name: license-api-service, namespace: ott-platform }
 spec:
   selector: { app: license-api }
   ports: [ { name: http, port: 80, targetPort: 5003 } ]
----
-apiVersion: v1
-kind: ConfigMap
-metadata: { name: license-api-code, namespace: ott-platform }
-data:
-  app.py: |
-    from flask import Flask, request, jsonify
-    from prometheus_flask_exporter import PrometheusMetrics
-    app = Flask(__name__); metrics = PrometheusMetrics(app)
-    @app.get("/health")
-    def h(): return ("ok",200)
-    @app.get("/ready")
-    def r(): return ("ok",200)
-    @app.post("/license")
-    def license_issue():
-      b = request.get_json(force=True) or {}
-      if not b.get("contentId") or not b.get("deviceId"):
-        return jsonify(ok=False, error="missing fields"), 400
-      # Stub DRM OK
-      return jsonify(ok=True, licenseKey="ABC123-FAKE-KEY")
-    if __name__=="__main__": app.run(host="0.0.0.0", port=5003)

--- a/k8s/apis/subscription-api.yaml
+++ b/k8s/apis/subscription-api.yaml
@@ -9,9 +9,7 @@ spec:
     spec:
       containers:
       - name: subscription
-        image: python:3.11-slim
-        command: ["/bin/sh", "-c"]
-        args: ["pip install flask pyjwt prometheus_flask_exporter && python /app/app.py"]
+        image: ghcr.io/example/subscription-api:latest
         ports: [ { containerPort: 5001 } ]
         env: [ { name: JWT_SECRET, value: "super-secret-key" } ]
         readinessProbe:
@@ -25,8 +23,6 @@ spec:
         resources:
           requests: { cpu: "100m", memory: "128Mi" }
           limits:   { cpu: "300m", memory: "512Mi" }
-        volumeMounts: [ { name: code, mountPath: /app } ]
-      volumes: [ { name: code, configMap: { name: subscription-api-code } } ]
 ---
 apiVersion: v1
 kind: Service
@@ -34,27 +30,3 @@ metadata: { name: subscription-api-service, namespace: ott-platform }
 spec:
   selector: { app: subscription-api }
   ports: [ { name: http, port: 80, targetPort: 5001 } ]
----
-apiVersion: v1
-kind: ConfigMap
-metadata: { name: subscription-api-code, namespace: ott-platform }
-data:
-  app.py: |
-    from flask import Flask, request, jsonify
-    import jwt
-    from prometheus_flask_exporter import PrometheusMetrics
-    app = Flask(__name__)
-    SECRET = "super-secret-key"; metrics = PrometheusMetrics(app)
-    @app.get("/health")
-    def h(): return ("ok",200)
-    @app.get("/ready")
-    def r(): return ("ok",200)
-    @app.get("/subscription/check/<content_id>")
-    def check(content_id):
-        try:
-            token = request.headers.get("Authorization","").split(" ")[1]
-            jwt.decode(token, SECRET, algorithms=["HS256"])
-            return jsonify(entitled=(content_id!="blocked123"))
-        except Exception as e:
-            return jsonify(error="unauthorized", detail=str(e)), 401
-    if __name__=="__main__": app.run(host="0.0.0.0", port=5001)


### PR DESCRIPTION
## Summary
- add Python source and Dockerfiles for auth, catalog, subscription, license, and CAS APIs
- reference published images in Kubernetes deployments and drop ConfigMaps
- ignore Python cache files

## Testing
- `python -m py_compile apis/*/app.py`
- `docker build -t ghcr.io/example/auth-api:latest apis/auth` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be0fc319e08325a9e4b6a696565633