### PR TITLE
Use Kubernetes Secret for JWT key

### DIFF
--- a/k8s/apis/auth-api.yaml
+++ b/k8s/apis/auth-api.yaml
@@ -13,6 +13,7 @@ spec:
         command: ["/bin/sh", "-c"]
         args: ["pip install flask pyjwt prometheus_flask_exporter && python /app/app.py"]
         ports: [ { containerPort: 5000 } ]
+        envFrom: [ { secretRef: { name: jwt-secret } } ]
         readinessProbe:
           httpGet: { path: /health, port: 5000 }
           initialDelaySeconds: 5
@@ -40,9 +41,11 @@ metadata: { name: auth-api-code, namespace: ott-platform }
 data:
   app.py: |
     from flask import Flask, request, jsonify
-    import jwt, datetime
+    import jwt, datetime, os
     from prometheus_flask_exporter import PrometheusMetrics
-    app = Flask(__name__); SECRET="super-secret-key"; metrics = PrometheusMetrics(app)
+    app = Flask(__name__)
+    SECRET = os.environ.get("JWT_SECRET")
+    metrics = PrometheusMetrics(app)
     @app.get("/health")
     def h(): return ("ok",200)
     @app.post("/auth/login")

--- a/k8s/apis/jwt-secret.yaml
+++ b/k8s/apis/jwt-secret.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Secret
+metadata: { name: jwt-secret, namespace: ott-platform }
+type: Opaque
+stringData: { JWT_SECRET: super-secret-key }

--- a/k8s/apis/subscription-api.yaml
+++ b/k8s/apis/subscription-api.yaml
@@ -13,7 +13,7 @@ spec:
         command: ["/bin/sh", "-c"]
         args: ["pip install flask pyjwt prometheus_flask_exporter && python /app/app.py"]
         ports: [ { containerPort: 5001 } ]
-        env: [ { name: JWT_SECRET, value: "super-secret-key" } ]
+        envFrom: [ { secretRef: { name: jwt-secret } } ]
         readinessProbe:
           httpGet: { path: /health, port: 5001 }
           initialDelaySeconds: 5
@@ -41,10 +41,11 @@ metadata: { name: subscription-api-code, namespace: ott-platform }
 data:
   app.py: |
     from flask import Flask, request, jsonify
-    import jwt
+    import jwt, os
     from prometheus_flask_exporter import PrometheusMetrics
     app = Flask(__name__)
-    SECRET = "super-secret-key"; metrics = PrometheusMetrics(app)
+    SECRET = os.environ.get("JWT_SECRET")
+    metrics = PrometheusMetrics(app)
     @app.get("/health")
     def h(): return ("ok",200)
     @app.get("/ready")


### PR DESCRIPTION
## Summary
- store JWT secret in dedicated Kubernetes Secret
- load JWT secret into auth-api and subscription-api via envFrom
- remove hard-coded secret values from ConfigMaps

## Testing
- `kubectl version --client`
- `apt-get update`


------
https://chatgpt.com/codex/tasks/task_e_68be0fc466bc8325bc2de93acf905832