### PR TITLE
Add health probes and resource limits

### DIFF
--- a/k8s/cdn/cdn-edge.yaml
+++ b/k8s/cdn/cdn-edge.yaml
@@ -34,6 +34,9 @@ spec:
       - name: nginx
         image: nginx:1.25-alpine
         ports: [ { containerPort: 80 } ]
+        resources: { requests: { cpu: "100m", memory: "128Mi" }, limits: { cpu: "200m", memory: "256Mi" } }
+        readinessProbe: { httpGet: { path: /health, port: 80 }, initialDelaySeconds: 5, periodSeconds: 10 }
+        livenessProbe: { httpGet: { path: /health, port: 80 }, initialDelaySeconds: 5, periodSeconds: 10 }
         volumeMounts:
         - { name: nginx-config, mountPath: /etc/nginx/conf.d }
         - { name: cache, mountPath: /var/cache/nginx }

--- a/k8s/player/hls-player.yaml
+++ b/k8s/player/hls-player.yaml
@@ -12,6 +12,8 @@ data:
       const url='http://cdn-edge-service.ott-platform.svc.cluster.local/media/demo/master.m3u8';
       if(Hls.isSupported()){const h=new Hls();h.loadSource(url);h.attachMedia(v);}else if(v.canPlayType('application/vnd.apple.mpegurl')){v.src=url;}
     </script></body></html>
+  health: |
+    ok
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -26,6 +28,9 @@ spec:
       - name: player
         image: nginx:1.25-alpine
         ports: [ { containerPort: 80 } ]
+        resources: { requests: { cpu: "50m", memory: "64Mi" }, limits: { cpu: "100m", memory: "128Mi" } }
+        readinessProbe: { httpGet: { path: /health, port: 80 }, initialDelaySeconds: 5, periodSeconds: 10 }
+        livenessProbe: { httpGet: { path: /health, port: 80 }, initialDelaySeconds: 5, periodSeconds: 10 }
         volumeMounts: [ { name: html, mountPath: /usr/share/nginx/html } ]
       volumes: [ { name: html, configMap: { name: player-config } } ]
 ---

--- a/k8s/vlc/hls-transcoder.yaml
+++ b/k8s/vlc/hls-transcoder.yaml
@@ -1,3 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+metadata: { name: hls-transcoder-nginx-config, namespace: ott-platform }
+data:
+  default.conf: |
+    server {
+      listen 80;
+      location /health { return 200 "ok\n"; add_header Content-Type text/plain; }
+    }
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata: { name: hls-transcoder, namespace: ott-platform, labels: { app: hls-transcoder } }
@@ -12,6 +22,7 @@ spec:
         emptyDir: {}
       - name: video-src
         hostPath: { path: /ABSOLUTE/PATH/TO/video-source, type: Directory }  # TODO: usuario lo ajusta
+      - { name: nginx-config, configMap: { name: hls-transcoder-nginx-config } }
       containers:
       - name: ffmpeg
         image: jrottenberg/ffmpeg:6.0-alpine
@@ -22,14 +33,19 @@ spec:
             -c:v libx264 -preset veryfast -c:a aac -f hls
             -hls_time 4 -hls_list_size 0
             -hls_segment_filename /hls/seg_%03d.ts /hls/master.m3u8
+        resources: { requests: { cpu: "500m", memory: "512Mi" }, limits: { cpu: "1000m", memory: "1Gi" } }
         volumeMounts:
         - { name: hls, mountPath: /hls }
         - { name: video-src, mountPath: /video }
       - name: nginx
         image: nginx:1.25-alpine
         ports: [ { containerPort: 80 } ]
+        resources: { requests: { cpu: "100m", memory: "128Mi" }, limits: { cpu: "200m", memory: "256Mi" } }
+        readinessProbe: { httpGet: { path: /health, port: 80 }, initialDelaySeconds: 5, periodSeconds: 10 }
+        livenessProbe: { httpGet: { path: /health, port: 80 }, initialDelaySeconds: 5, periodSeconds: 10 }
         volumeMounts:
         - { name: hls, mountPath: /usr/share/nginx/html/media/demo }
+        - { name: nginx-config, mountPath: /etc/nginx/conf.d }
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
## Summary
- add readiness/liveness probes at `/health` for cdn-edge, hls-player and hls-transcoder
- define CPU/memory requests and limits for all containers
- add nginx config and files to serve health endpoints

## Testing
- `kubectl apply --dry-run=client -f k8s/cdn/cdn-edge.yaml` *(fails: command not found)*
- `apt-get update` *(fails: The repository ... is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68be0fc59c8483259795067990dc05dd