### PR TITLE
Pin k6 image version in load test job

### DIFF
--- a/k8s/testing/k6-job.yaml
+++ b/k8s/testing/k6-job.yaml
@@ -6,7 +6,7 @@ spec:
     spec:
       containers:
       - name: k6
-        image: grafana/k6:latest
+        image: grafana/k6:0.45.0
         command: ["k6","run","/scripts/ott-load-test.js"]
         volumeMounts: [ { name: scripts, mountPath: /scripts } ]
       restartPolicy: Never


### PR DESCRIPTION
## Summary
- pin grafana/k6 image to version 0.45.0
- verify all manifest images use fixed versions

## Testing
- `kubectl apply --dry-run=client -f k8s` *(fails: command not found)*
- `yamllint k8s` *(fails: command not found)*
- `pip install yamllint` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68be0fc7c0808325a07ba94b5629c8d7